### PR TITLE
Bump python version number 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ package_dir =
     =src
 
 # Require a min/specific Python version (comma-separated conditions)
-python_requires = >=3.11, <3.13
+python_requires = >=3.11, <3.14
 
 # Add here dependencies of your project (line-separated), e.g. requests>=2.2,<3.0.
 # Version specifiers like >=2.2,<3.0 avoid problems due to API changes in


### PR DESCRIPTION
It seems the issue we were having with python 3.13 has been resolved. Tests ran fine (with the exception of the convergence exception, which currently fails even for python 3.12 and should be fixed separately). 